### PR TITLE
Update felin.raceeffect-Falldamage

### DIFF
--- a/species/felin.raceeffect
+++ b/species/felin.raceeffect
@@ -4,6 +4,7 @@
 		{ "stat": "maxEnergy", "baseMultiplier": 0.95 },
 		{ "stat": "powerMultiplier", "baseMultiplier": 1.05 },
 		{ "stat": "poisonResistance", "amount": -0.4 },
+		{ "stat" : "fallDamageMultiplier", "baseMultiplier" : 0.25 },
 		{ "stat": "shadowResistance", "amount": 0.4 }
 	],
 	"diet" : "carnivore",


### PR DESCRIPTION
The felin race has in it´s description a Falldamage resistance of 75% but it is not implemented in it´s raceeffect. This should fix it.